### PR TITLE
修复了某些情况下页数控制器可能不显示的问题

### DIFF
--- a/BHInfiniteScrollView/BHInfiniteScrollView/BHInfiniteScrollView.m
+++ b/BHInfiniteScrollView/BHInfiniteScrollView/BHInfiniteScrollView.m
@@ -86,7 +86,6 @@
     
     
     [self setupPageControl];
-    [self updatePageControl];
     [self updateTitleView];
     
     //scroll to middle postion
@@ -240,7 +239,7 @@
     
     [self.collectionView reloadData];
     [self scrollToMiddlePosition];
-    [self updatePageControl];
+    [self setupPageControl];
 }
 
 - (void)setScrollDirection:(BHInfiniteScrollViewScrollDirection)scrollDirection {


### PR DESCRIPTION
当进入`setImagesArray:`方法时,`self.pageControl`有可能为nil,所以把`updatePageControl`换成了`setupPageControl`,`setupPageControl`方法后面会自动调用`setupPageControl``,layoutSubViews`里这两个方法都有,我就把`layoutSubViews`里的`[self updatePageControl];`去掉了.
